### PR TITLE
Remove 'ms-python.isort' devcontainer extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,6 @@
                 "GitHub.copilot-chat",
                 "GitHub.vscode-pull-request-github",
                 "ms-python.debugpy",
-                "ms-python.isort",
                 "ms-python.python",
                 "ms-python.vscode-pylance",
                 "ms-vscode.cpptools",


### PR DESCRIPTION
This extension is buggy and throws an error that Python isn't installed when loading the container in codespaces. This extension isn't needed and can be removed.