### PR TITLE
Adding styles to gem5.css

### DIFF
--- a/slides/themes/gem5.css
+++ b/slides/themes/gem5.css
@@ -19,6 +19,7 @@
 }
 
 section {
+    color: black;
     font-size: 1.6rem;
     font-family: sans-serif;
     line-height: 2rem;
@@ -177,6 +178,26 @@ section.two-col h3 {
 section.center-image img {
     display: block;
     margin: auto;
+}
+
+/****************************************************/
+/* For title cards at the beginning of a section, e.g. Intro to ..., etc.
+   Has a blue gradient. From Erin and Mysore
+*/
+section.start h2 {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+    font-size: 4rem;
+    font-weight: bold;
+    line-height: 75px;
+    background: linear-gradient(to right,rgb(67,124,205), rgb(69,214,202));
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
 }
 
 /****************************************************/


### PR DESCRIPTION
This commit adds various styles to gem5.css. The added styles allow you to center a single image, to place code blocks/text/images side by side, to make a centered title with a blue gradient, and to make a title that is side-by-side with a subtitle.