### PR TITLE
slides: Add center-image class

### DIFF
--- a/slides/README.md
+++ b/slides/README.md
@@ -39,6 +39,7 @@ Here are some of the available layouts:
 
 - `title`: Title slide
 - `twoCol`: Two columns. To split the slide into two columns, use `###` (heading 3) to create a new column.
+- `center-image`: Centers images horizontally
 
 ## Adding diagrams
 

--- a/slides/themes/gem5.css
+++ b/slides/themes/gem5.css
@@ -173,6 +173,13 @@ section.twoCol h3 {
 }
 
 /****************************************************/
+/* For centering images */
+section.center-image img {
+    display: block;
+    margin: auto;
+}
+
+/****************************************************/
 /* For code block */
 
 pre {


### PR DESCRIPTION
Adds `center-image` section class which horizontally centers images in the slide. This can be easily used in conjunction with other classes as long as they don't affect `img` tags as well.

Note: I realize this class name has a different styling to `twoCols`. Canonically, CSS classes should be in this hyphenated style, but not sure what the preference is here. I can easily change this to `centerImage` or change `twoCols` to `two-cols`, whichever is preferred.