### PR TITLE
Increasing devcontainer.json host requirements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,8 @@
     "name": "gem5 Development Container",
     "image": "ghcr.io/gem5/devcontainer:bootcamp-2024",
     "hostRequirements": {
-        "cpus": 1,
-        "memory": "8gb",
+        "cpus": 4,
+        "memory": "16gb",
         "storage": "64gb"
      },
     "customizations": {


### PR DESCRIPTION
This won't change the current VM size selected on GitHub but more explicitly states the requirements, in particular the 16GB memory and 64GB storage. Due to the 64GB storage setting the "8-core, 32GB, 64GB" GitHub Codespace machine time was being selected which meets this requirement amyway. However, it's best to be explicit.