### PR TITLE
Update Extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,9 @@
                 "Tsinghua-Hexin-Joint-Institute.gem5-slicc",
                 "ms-python.black-formatter",
                 "marp-team.marp-vscode",
-                "hediet.vscode-drawio"
+                "hediet.vscode-drawio",
+                "ms-vsliveshare.vsliveshare",
+                "DavidAnson.vscode-markdownlint"
             ]
         }
     },


### PR DESCRIPTION
Added extensions:
- The Markdown linter.
- VSCode Liveshare

Removed extensions:
- Python Black - not needed or used.