### PR TITLE
Small code classes

### DIFF
--- a/slides/02-Using-gem5/02-gem5-resources.md
+++ b/slides/02-Using-gem5/02-gem5-resources.md
@@ -223,7 +223,7 @@ lets run the simulation and see the output
 
 ---
 
-<!-- _class: tooMuchCode -->
+<!-- _class: code-50-percent -->
 
 ## Lets create a JSON file for the binary resource
 

--- a/slides/02-Using-gem5/03-running-in-gem5.md
+++ b/slides/02-Using-gem5/03-running-in-gem5.md
@@ -213,6 +213,8 @@ write(1, "This will be output to standard out\n", 36);
 
 ---
 
+<!-- _class: code-80-percent -->
+
 ## 02-annotate-this
 
 and output all the files and folders names in the current directory

--- a/slides/03-Developing-gem5-models/05-modeling-cores.md
+++ b/slides/03-Developing-gem5-models/05-modeling-cores.md
@@ -214,7 +214,7 @@ You can follow this call through to `Decoder:: decode` which can be found in [sr
 
 ---
 
-<!-- _class: small-code -->
+<!-- _class: code-60-percent -->
 
 ```cpp
 StaticInstPtr
@@ -506,6 +506,8 @@ decode QUADRANT default Unknown::unknown() {
 
 ---
 
+<!-- _class: code-80-percent -->
+
 ### Generating code from the LW ISA definition
 
 You can compare side by side decoder.isa and decode-method.cc.inc to see how the ISA definition is used to generate the CPP decoder code.
@@ -598,6 +600,8 @@ StaticInstPtr RiscvISA::Decoder::decodeInst(RiscvISA::ExtMachInst machInst) {
 
 ---
 
+<!-- _class: code-50-percent -->
+
 ### The generated function to execute the LW instruction
 
 ```cpp
@@ -619,7 +623,6 @@ StaticInstPtr RiscvISA::Decoder::decodeInst(RiscvISA::ExtMachInst machInst) {
 If you go to the declaration of `Load` in "src/arch/riscv/isa/formats/mem.isa" you can figure out how this was constructed:
 
 ```txt
-
 def format Load(memacc_code, ea_code = {{EA = rvZext(Rs1 + offset);}},
         offset_code={{offset = sext<12>(IMM12);}},
         mem_flags=[], inst_flags=[]) {{
@@ -666,7 +669,9 @@ The generated is valid CPP code and can understood by trying to  understanding t
 
 Using breakpoints in GDB to trace the execution of an instruction in gem5 is a good way to understand how the generated code is used to decode and execute an instruction.
 
-___
+---
+
+<!-- _class: code-50-percent -->
 
 ## Exercise: Implement `ADD16` instruction
 
@@ -675,9 +680,7 @@ In this inxercise you're going to implement `ADD16` to the gem5 RISC-V ISA.
 The `ADD16` instruction is a 16-bit addition instruction that adds two 16-bit values and stores the result in a 16-bit register.
 
 Format:
-
 ```txt
-
 | 31 -- 25 | 24 -- 20 | 19 -- 15 | 14 -- 12 | 11 -- 7 |  6 -- 0  |
 |  0100000 |   rs2    |   rs1    |   000    |   rd    |  0110011 |
 |  funct7  |          |          |  funct3  |         |  opcode  |

--- a/slides/03-Developing-gem5-models/06-modeling-cache-coherence.md
+++ b/slides/03-Developing-gem5-models/06-modeling-cache-coherence.md
@@ -308,7 +308,7 @@ While we're waiting on the compilation, let's look at some of the details of the
 
 ---
 
-<!-- _class: "tooMuchCode" -->
+<!-- _class: code-60-percent -->
 
 ## Let's look at some code: In-port definition
 
@@ -649,6 +649,7 @@ Runs scons and python script
 
 ------
 
+<!-- _class: code-60-percent -->
 
 ## Fixing the error: Deadlock
 
@@ -680,6 +681,8 @@ build/ALL_MyMSI/gem5.opt --debug-flags=ProtocolTrace configs/learning_gem5/part3
 
 ---
 
+<!-- _class: code-80-percent -->
+
 ## Fixing the error: What to do on a store
 
 - Fix the next error (what to do on a store??)
@@ -703,6 +706,8 @@ build/ALL_MyMSI/gem5.opt --debug-flags=ProtocolTrace configs/learning_gem5/part3
 Run scons and python script
 
 ---
+
+<!-- _class: code-60-percent -->
 
 ## Final error: What to do when there is sharing?
 

--- a/slides/README.md
+++ b/slides/README.md
@@ -50,6 +50,7 @@ Here are some of the available layouts:
 - `title`: Title slide
 - `two-col`: Two columns. To split the slide into two columns, use `###` (heading 3) to create a new column.
 - `center-image`: Centers images horizontally
+- `code-XX-percent`: Reduces font-size in code blocks. Valid values for `XX` are any of `[50, 60, 70, 80]`.
 
 ## Adding diagrams
 

--- a/slides/themes/gem5.css
+++ b/slides/themes/gem5.css
@@ -16,6 +16,9 @@
     --gem5-background: #F6F8FA;
     --gem5-light: #c8eaf3;
     --gem5-dark: #00627a;
+
+    --code-line-height: 2rem;
+    --code-font-size: 1.4rem;
 }
 
 section {
@@ -239,25 +242,49 @@ section.outline h3 {
 }
 
 /****************************************************/
+/* For reducing size of code blocks */
+section.code-50-percent pre {
+    line-height: calc(var(--code-line-height) * 0.33);
+}
+section.code-50-percent pre code {
+    font-size: calc(var(--code-font-size) * 0.5);
+}
+
+section.code-60-percent pre {
+    line-height: calc(var(--code-line-height) * 0.48);
+}
+section.code-60-percent pre code {
+    font-size: calc(var(--code-font-size) * 0.6);
+}
+
+section.code-70-percent pre {
+    line-height: calc(var(--code-line-height) * 0.65);
+}
+section.code-70-percent pre code {
+    font-size: calc(var(--code-font-size) * 0.7);
+}
+
+section.code-80-percent pre {
+    line-height: calc(var(--code-line-height) * 0.8);
+}
+section.code-80-percent pre code {
+    font-size: calc(var(--code-font-size) * 0.8);
+}
+
+/****************************************************/
 /* For code block */
 
 pre {
     padding: 10px;
     border-radius: 5px;
+    line-height: var(--code-line-height);
     background-color: #ffffff;
 }
 
 code {
     font-family: "Roboto Mono", monospace;
-    font-size: 1.4rem;
+    font-size: var(--code-font-size);
     background-color: #ffffff;
-}
-
-/****************************************************/
-/* For centering images */
-section.center-image img {
-    display: block;
-    margin: auto;
 }
 
 /*!


### PR DESCRIPTION
Adds four CSS classes for reducing code font-size. Of the form `code-XX-percent` where each of `[50, 60, 70, 80]` are defined.

I also went through some of the relatively finalized slides and added classes where needed. Each file has its own commit, so any of these can easily be dropped if these changes are premature.