### PR TITLE
Logo classes

### DIFF
--- a/slides/01-Introduction/01-simulation-background.md
+++ b/slides/01-Introduction/01-simulation-background.md
@@ -67,6 +67,8 @@ Nathan Binkert, Bradford Beckmann, Gabriel Black, Steven K. Reinhardt, Ali Saidi
 
 ---
 
+<!-- _class: no-logo -->
+
 ## gem5-20+: A new era in computer architecture simulation
 
 ![gem5-20+](./01-simulation-background-imgs/gem5-20plus.drawio.png)
@@ -93,6 +95,8 @@ Nathan Binkert, Bradford Beckmann, Gabriel Black, Steven K. Reinhardt, Ali Saidi
 ### We're close… just a lot of rough edges! You can help!
 
 ---
+
+<!-- _class: logo-left -->
 
 ## The gem5 community
 

--- a/slides/02-Using-gem5/05-cache-hierarchies.md
+++ b/slides/02-Using-gem5/05-cache-hierarchies.md
@@ -22,7 +22,7 @@ scons build/NULL_MESI_Two_Level/gem5.opt --default=NULL PROTOCOL=MESI_Two_Level 
 
 ---
 
-<!-- _class: twoCol -->
+<!-- _class: two-col -->
 
 ## Cache Hierarchy in gem5
 
@@ -76,7 +76,7 @@ A coherence problem can arise if multiple cores have access to multiple copies o
 
 ---
 
-<!-- _class: twoCol -->
+<!-- _class: two-col -->
 
 ## Snoop Protocol
 
@@ -92,7 +92,7 @@ A coherence problem can arise if multiple cores have access to multiple copies o
 
 ---
 
-<!-- _class: twoCol -->
+<!-- _class: two-col -->
 
 ## Directory Protocol
 
@@ -167,7 +167,7 @@ Parameters:
 
 ---
 
-<!-- _class: twoCol -->
+<!-- _class: two-col -->
 
 ## Ruby Cache
 
@@ -180,6 +180,8 @@ Parameters:
 ![w:600 System with Ruby Caches](05-cache-hierarchies/ruby_cache.drawio.svg)
 
 ---
+
+<!-- _class: no-logo center-image -->
 
 ## Ruby
 

--- a/slides/03-Developing-gem5-models/05-modeling-cores.md
+++ b/slides/03-Developing-gem5-models/05-modeling-cores.md
@@ -671,7 +671,7 @@ Using breakpoints in GDB to trace the execution of an instruction in gem5 is a g
 
 ---
 
-<!-- _class: code-50-percent -->
+<!-- _class: code-50-percent no-logo -->
 
 ## Exercise: Implement `ADD16` instruction
 

--- a/slides/03-Developing-gem5-models/06-modeling-cache-coherence.md
+++ b/slides/03-Developing-gem5-models/06-modeling-cache-coherence.md
@@ -35,6 +35,8 @@ M5 + GEMS = gem5
 
 ---
 
+<!-- _class: center-image -->
+
 ## Cache Coherence Reminder
 
 Single-Writer Multiple-Reader (SWMR) invariant
@@ -44,6 +46,7 @@ Single-Writer Multiple-Reader (SWMR) invariant
 ---
 
 <!-- _paginate: hold -->
+<!-- _class: center-image -->
 
 ## Cache Coherence Reminder
 
@@ -53,11 +56,15 @@ Single-Writer Multiple-Reader (SWMR) invariant
 
 ---
 
+<!-- _class: center-image -->
+
 ## Ruby Architecture
 
 ![ruby architecture: classic ports on each side of a black box](06-modeling-cache-coherence-imgs/ruby-architecture.drawio.svg)
 
 ---
+
+<!-- _class: center-image -->
 
 ## Ruby Inside the Black Box
 
@@ -649,7 +656,7 @@ Runs scons and python script
 
 ------
 
-<!-- _class: code-60-percent -->
+<!-- _class: code-60-percent no-logo -->
 
 ## Fixing the error: Deadlock
 
@@ -812,7 +819,7 @@ for ri in self.routers:
 
 ## Ports to Ruby to ports interface
 
-![bg right](06-modeling-cache-coherence-imgs/ruby-architecture.drawio.svg)
+![bg right width:600](06-modeling-cache-coherence-imgs/ruby-architecture.drawio.svg)
 
 Remember this picture?
 

--- a/slides/README.md
+++ b/slides/README.md
@@ -51,6 +51,8 @@ Here are some of the available layouts:
 - `two-col`: Two columns. To split the slide into two columns, use `###` (heading 3) to create a new column.
 - `center-image`: Centers images horizontally
 - `code-XX-percent`: Reduces font-size in code blocks. Valid values for `XX` are any of `[50, 60, 70, 80]`.
+- `no-logo`: Removes the bottom logo.
+- `logo-left`: Positions the bottom logo further to the left. Useful when using `bg right` images that cover the logo.
 
 ## Adding diagrams
 

--- a/slides/themes/gem5.css
+++ b/slides/themes/gem5.css
@@ -184,6 +184,15 @@ section.center-image img {
 }
 
 /****************************************************/
+/* For altering logo position/appearance */
+section.logo-left {
+    background-position-x: 21%;
+}
+section.no-logo {
+    background-image: none;
+}
+
+/****************************************************/
 /* For title cards at the beginning of a section, e.g. Intro to ..., etc.
    Has a blue gradient. From Erin and Mysore
 */


### PR DESCRIPTION
Adds `no-logo` and `logo-left` section classes that affect the bottom logo on the slide. `no-logo` removes the bottom logo, and `logo-left` shifts the logo left to around the 25% mark -- useful when using `bg right` images that partially cover the logo.

As with the last PR, I also went around and added these and other relevant style fixes to some of the slides -- mainly focusing on the Jason ones to avoid conflicts with those unaware of this PR.