### PR TITLE
fix typo in 02-getting-started.md

### DIFF
--- a/slides/01-Introduction/02-getting-started.md
+++ b/slides/01-Introduction/02-getting-started.md
@@ -244,7 +244,7 @@ sim.run(20_000_000_000) # 20 billion ticks or 20 ms
 To run it:
 
 ```sh
-gem5 basic.py
+gem5-mesi basic.py
 ```
 
 ---


### PR DESCRIPTION
change the instructions from saying to use `gem5 basic.py` to `gem5-mesi basic.py` as done in the bootcamp