### PR TITLE
Fix slide bullets

### DIFF
--- a/slides/02-Using-gem5/05-cache-hierarchies.md
+++ b/slides/02-Using-gem5/05-cache-hierarchies.md
@@ -47,13 +47,13 @@ More on Ruby in [Modeling Cache Coherence in gem5](../03-Developing-gem5-models/
 
 ## Outline
 
-* Background on cache coherency
-* Simple Cache
-  * Coherency protocol in simple cache
-  * How to use simple cache
-* Ruby cache
-  * Ruby components
-  * Example of MESI two level protocol
+- Background on cache coherency
+- Simple Cache
+  - Coherency protocol in simple cache
+  - How to use simple cache
+- Ruby cache
+  - Ruby components
+  - Example of MESI two level protocol
 
 ---
 
@@ -312,17 +312,17 @@ This has both full-system (with x86) and SE mode (with Arm).
 
 ## Classic Cache: Parameters
 
-* src/mem/cache/Cache.py
-  * src/mem/cache/cache.cc
-  * src/mem/cache/noncoherent_cache.cc
+- src/mem/cache/Cache.py
+  - src/mem/cache/cache.cc
+  - src/mem/cache/noncoherent_cache.cc
 
 Parameters:
 
-* size
-* associativity
-* number of miss status handler register (MSHR) entries
-* prefetcher
-* replacement policy
+- size
+- associativity
+- number of miss status handler register (MSHR) entries
+- prefetcher
+- replacement policy
 
 ---
 
@@ -350,10 +350,10 @@ Parameters:
 
 ## Ruby Components
 
-* **Controller models** (cache controller, directory controller)
-* **Controller topology** (Mesh, all-to-all, etc.)
-* **Network models**
-* **Interface** (classic ports)
+- **Controller models** (cache controller, directory controller)
+- **Controller topology** (Mesh, all-to-all, etc.)
+- **Network models**
+- **Interface** (classic ports)
 
 ### Ruby Cache: Controller Models
 
@@ -425,8 +425,8 @@ Compare the following stats:
 
 The time it took in simulation and the read/write sharing
 
-* `board.cache_hierarchy.ruby_system.L1Cache_Controller.Fwd_GETS`: Number of times things were read-shared
-* `board.cache_hierarchy.ruby_system.L1Cache_Controller.Fwd_GETX`: Number of times things were write-shared
+- `board.cache_hierarchy.ruby_system.L1Cache_Controller.Fwd_GETS`: Number of times things were read-shared
+- `board.cache_hierarchy.ruby_system.L1Cache_Controller.Fwd_GETX`: Number of times things were write-shared
 
 (Note: Ignore the first thing in the array for these stats. It's a long story...)
 
@@ -436,8 +436,8 @@ We'll cover more about how to configure Ruby in [Modeling Cache Coherence in gem
 
 ## Summary
 
-* Cache hierarchies are a key part of gem5
-* Classic caches are simpler and faster
-* Classic caches are straightforward to configure and use
-* Ruby caches are more detailed and can model cache coherence
-* We can use Ruby to compare different cache behaviors
+- Cache hierarchies are a key part of gem5
+- Classic caches are simpler and faster
+- Classic caches are straightforward to configure and use
+- Ruby caches are more detailed and can model cache coherence
+- We can use Ruby to compare different cache behaviors

--- a/slides/03-Developing-gem5-models/05-modeling-cores.md
+++ b/slides/03-Developing-gem5-models/05-modeling-cores.md
@@ -17,10 +17,10 @@ The _Instuction Set Architecture_ (ISA) is the interface between the software an
 
 An ISA defines:
 
-* The instructions that a processesor can exectue.
-* The registers that are available
-* The memory model
-* Exception and interrupt handling
+- The instructions that a processesor can exectue.
+- The registers that are available
+- The memory model
+- Exception and interrupt handling
 
 ---
 
@@ -30,11 +30,11 @@ An ISA defines:
 
 ## ISA's gem5 can simulate
 
-* ARM
-* RISC-V
-* x86
-* MIPS
-* SPARC
+- ARM
+- RISC-V
+- x86
+- MIPS
+- SPARC
 
 Realistically you'll probably only use ARM, RISC-V, and x86.
 
@@ -70,14 +70,14 @@ A `StaticInst` is an object containing static information about a particular ISA
 
 It contains information on
 
-* The operation class
-* Source and destination registers
-* Flags to show if the instruction has micro-ops
-* Functions defining the instruction's behavior
-  * `execute()`
-  * `initiateAcc()`
-  * `completeAcc()`
-  * `dissasemble()`
+- The operation class
+- Source and destination registers
+- Flags to show if the instruction has micro-ops
+- Functions defining the instruction's behavior
+  - `execute()`
+  - `initiateAcc()`
+  - `completeAcc()`
+  - `dissasemble()`
 
 ---
 
@@ -88,12 +88,12 @@ They are constructed from information in the `StaticInst` objects.
 
 They contains information on:
 
-* PC and predicated next-PC
-* Instruction result
-* Thread number
-* CPU
-* Renamed register indices
-* Provides the `ExecContext` interface
+- PC and predicated next-PC
+- Instruction result
+- Thread number
+- CPU
+- Renamed register indices
+- Provides the `ExecContext` interface
 
 ---
 
@@ -409,12 +409,12 @@ The base instruction formats are the R, I, S, B, U, and J types which use thye f
 
 ---
 
-* R type: for register-register operations.
-* I type: for immediate and load operations.
-* S type: for store operations.
-* B type: for branch operations.
-* U type: for upper immediate operations.
-* J type: for jump operations.
+- R type: for register-register operations.
+- I type: for immediate and load operations.
+- S type: for store operations.
+- B type: for branch operations.
+- U type: for upper immediate operations.
+- J type: for jump operations.
 
 ---
 
@@ -427,10 +427,10 @@ It is defined by the folowing format:
 LW rd,offset(rs1) # rd = mem[rs1+imm]
 ```
 
-* `lw` is the mnemonic for the instruction.
-* `rd` is the destination register.
-* `imm` immediate value: termines the offset (can be used to access sub-word data).
-* `rs1` is the source register.
+- `lw` is the mnemonic for the instruction.
+- `rd` is the destination register.
+- `imm` immediate value: termines the offset (can be used to access sub-word data).
+- `rs1` is the source register.
 
 It loads the value of source register  `rs1` into the destination register `rd + imm`. If `imm` is zero, the full word (32-bits) of `rs1` is loaded into `rd`. This `imm` value is used to load subword data. However, if non-zero, `imm` is used to load subword data. `imm` shifts the bits in the `rs1` register prior to loading to `rd`. So, if `imm = 15`, the value of `rs1` is shifted by 15 bits before being loaded into `rd`.
 
@@ -763,10 +763,10 @@ Let's work backwards and specify each bit field in the instruction format.
 |  funct7  |          |          |  funct3  |         |  opcode  |
 ```
 
-* quadrant: 0x3
-* opcode5: 0x1d
-* funct3: 0x0
-* funct7: 0x20
+- quadrant: 0x3
+- opcode5: 0x1d
+- funct3: 0x0
+- funct7: 0x20
 
 ---
 


### PR DESCRIPTION
Fixes certain slides rendering their bullet points across multiple slides.

Fixed by using `-` instead of `*` to denote the bullet points.