### PR TITLE
Update resource links to point to dist.gem5.org from google could

### DIFF
--- a/.devcontainer/on_create.sh
+++ b/.devcontainer/on_create.sh
@@ -25,8 +25,8 @@ docker pull ghcr.io/gem5/gcn-gpu:v24-0
 
 wget http://dist.gem5.org/dist/v24-0/test-progs/square/square
 
-wget https://storage.googleapis.com/dist.gem5.org/dist/v24-0/gpu-fs/kernel/vmlinux-gpu-ml-isca
+wget  https://dist.gem5.org/dist/v24-0/gpu-fs/kernel/vmlinux-gpu-ml-isca
 
 # Note: this unzips to 55 GB so must in on /tmp.
 # See post_start.sh where it is unzipped each time the devcontainer starts
-wget https://storage.googleapis.com/dist.gem5.org/dist/v24-0/gpu-fs/diskimage/x86-ubuntu-gpu-ml-isca.gz
+wget  https://dist.gem5.org/dist/v24-0/gpu-fs/diskimage/x86-ubuntu-gpu-ml-isca.gz

--- a/slides/02-Using-gem5/07-full-system.md
+++ b/slides/02-Using-gem5/07-full-system.md
@@ -260,7 +260,7 @@ The general structure of the Packer file would be the same but with a few key ch
     Let's get the base Ubuntu 24.04 image from gem5 resources and unzip it.
 
     ```bash
-    wget https://storage.googleapis.com/dist.gem5.org/dist/develop/images/x86/ubuntu-24-04/x86-ubuntu-24-04.gz
+    wget https://dist.gem5.org/dist/develop/images/x86/ubuntu-24-04/x86-ubuntu-24-04.gz
     gzip -d x86-ubuntu-24-04.gz
     ```
 


### PR DESCRIPTION
- The backend of the resources have been moved to Azure storage from Google cloud, so this change updates the links to point to dist.gem5.org which has been updated to point to the new Azure storage.